### PR TITLE
Fix confetti cleanup

### DIFF
--- a/src/lib/components/Confetti.svelte
+++ b/src/lib/components/Confetti.svelte
@@ -80,14 +80,16 @@
 		confettiAnimationId = requestAnimationFrame(animateConfetti);
 	}
 
-	function stopConfetti() {
-		if (confettiAnimationId) {
-			cancelAnimationFrame(confettiAnimationId);
-			confettiAnimationId = undefined;
-            confettiContext!.clearRect(0, 0, canvas.width, canvas.height);
-		}
-		particles.length = 0;
-	}
+        function stopConfetti() {
+                if (confettiAnimationId) {
+                        cancelAnimationFrame(confettiAnimationId);
+                        confettiAnimationId = undefined;
+                }
+                if (confettiContext && canvas) {
+                        confettiContext.clearRect(0, 0, canvas.width, canvas.height);
+                }
+                particles.length = 0;
+        }
 
 	onDestroy(() => {
 		stopConfetti();


### PR DESCRIPTION
## Summary
- guard against calling clearRect when confetti isn't initialized

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_6843350d8a188332a543e620b0b16bfc